### PR TITLE
Expect aspect ratios as width over height, instead of height over width

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -4,17 +4,16 @@
   <head>
     <meta charset="utf-8">
     <title>&lt;blurhash-img> Demo</title>
-    <script type="module" src="../blurhash-img.js"></script>
+    <script type="module" src="../dist/blurhash-img.js"></script>
     <style>
-      p {
+      blurhash-img {
+        --aspect-ratio: 6 / 4;
         border: solid 1px blue;
-        padding: 8px;
+        width: 400px;
       }
     </style>
   </head>
   <body>
     <blurhash-img>
-      <p>This is child content</p>
-    </blurhash-img>
   </body>
 </html>

--- a/src/blurhash-img.ts
+++ b/src/blurhash-img.ts
@@ -24,7 +24,7 @@ export class BlurhashImg extends LitElement {
     .wrapper {
       position: relative;
       height: 0;
-      padding-bottom: calc(var(--aspect-ratio) * 100%);
+      padding-bottom: calc(100% / (var(--aspect-ratio)));
     }
 
     canvas {


### PR DESCRIPTION
This PR changes the way aspect ratios are used, to follow [the native CSS implementation](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#values).

I've also updated the dev setup slightly, to more easily verify the changes.